### PR TITLE
Allow app to make authenticated calls to Hasura using `@apollo/client`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ buck-out/
 # Expo
 .expo/xcodebuild-error.log
 .expo/xcodebuild.log
+.env.dev

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# rnauthstarter
+
+This app uses Auth0, and Hasura.
+
+## Connecting Hasura
+
+Following [this guide](https://hasura.io/blog/authentication-and-authorization-using-hasura-and-firebase/) to connect the app to Hasura with Authentication.
+
+N.B. This app uses Auth0 instead of Firebase, and sections below will highlight differences in the steps above.
+
+### Authentication
+From the guide:
+> Since we will use  JWT from Firebase, set HASURA_GRAPHQL_JWT_SECRET
+
+Instead of using Firebase, we use Auth0. To connect Auth0 as the authentication provider for the Hasura instance, see [this document](https://hasura.io/docs/latest/auth/authentication/jwt/#auth0-issues), and continue after the above instruction.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,28 @@ This app uses Auth0, and Hasura.
 
 Following [this guide](https://hasura.io/blog/authentication-and-authorization-using-hasura-and-firebase/) to connect the app to Hasura with Authentication.
 
-N.B. This app uses Auth0 instead of Firebase, and sections below will highlight differences in the steps above.
+N.B. This app uses Auth0 instead of Firebase, and sections below will highlight differences in the steps from the document above.
 
 ### Authentication
 From the guide:
 > Since we will use  JWT from Firebase, set HASURA_GRAPHQL_JWT_SECRET
 
-Instead of using Firebase, we use Auth0. To connect Auth0 as the authentication provider for the Hasura instance, see [this document](https://hasura.io/docs/latest/auth/authentication/jwt/#auth0-issues), and continue after the above instruction.
+Instead of using Firebase, we use Auth0. To connect Auth0 as the authentication provider for the Hasura instance, see [this video](https://youtu.be/2cvXfOLEJag?t=1156), and continue after the above instruction.
+
+Adding custom claims to Auth0, expected by Hasura:
+
+> Auth0 will inject custom claims into the JWT received by an authneticated user.
+
+In order for Hasura to determine the role based access level of the authorized user, custom claims are added to Auth0's authorization response. See [this link](https://hasura.io/docs/latest/guides/integrations/auth0-jwt/) 
+
+> The above document from Hasura uses Rules in Auth0 which is deprecated, use Actions instead.
+
+See [this link](https://auth0.com/docs/get-started/apis/scopes/sample-use-cases-scopes-and-claims) for how to add custom claims using Auth0 Actions.
+
+Once the Hasura console has been updated with the `jwk_url`, and Auth0's authorization response returns Hasura's custom claim, the rest of the guide can be followed to configure role based access to various tables in the data store.
+
+### Issues
+
+>It was observed that the access token received from Auth0 was malformed, consisting of 3 segments instead of 5 segments.
+
+ When logging in using a passwordless SMS verification, it may be required to enter the audience of the receiving API https://github.com/auth0/react-native-auth0/issues/349

--- a/app.config.js
+++ b/app.config.js
@@ -5,6 +5,8 @@ module.exports = {
   version: '1.0.0',
   extra: {
     AUTH0_DOMAIN: process.env.AUTH0_DOMAIN,
+    AUTH0_PASSWORDLESS_AUDIENCE: process.env.AUTH0_PASSWORDLESS_AUDIENCE,
     AUTH0_CLIENT_ID: process.env.AUTH0_CLIENT_ID,
+    HASURA_URL: process.env.HASURA_URL,
   },
 };

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
+    "@apollo/client": "^3.6.9",
     "@react-native-async-storage/async-storage": "^1.17.10",
     "@react-navigation/native": "^6.0.13",
     "@react-navigation/stack": "^6.3.0",
@@ -29,6 +30,7 @@
     "expo": "^46.0.0",
     "expo-constants": "~13.2.4",
     "firebase": "^9.10.0",
+    "graphql": "^16.6.0",
     "patch-package": "^6.4.7",
     "react": "18.1.0",
     "react-native": "0.70.1",

--- a/src/apollo/ApolloWrapper.tsx
+++ b/src/apollo/ApolloWrapper.tsx
@@ -1,0 +1,45 @@
+import React, {useMemo, useRef} from 'react';
+import {useSelector} from 'react-redux';
+import {authorizationTokenSelector} from '../auth/selectors';
+import {setContext} from '@apollo/client/link/context';
+import {
+  ApolloClient,
+  ApolloProvider,
+  InMemoryCache,
+  createHttpLink,
+} from '@apollo/client';
+import {HASURA_URL} from '../config';
+
+const ApolloWrapper = (props: any) => {
+  const {accessToken} = useSelector(authorizationTokenSelector) || {};
+  const tokenRef = useRef<string>();
+
+  tokenRef.current = accessToken;
+
+  const Client = useMemo(() => {
+    const httpLink = createHttpLink({
+      uri: HASURA_URL,
+    });
+
+    const authLink = setContext((_, {headers}) => {
+      // @note Return headers to context
+      return {
+        headers: {
+          ...headers,
+          Authorization: tokenRef.current ? `Bearer ${tokenRef.current}` : null,
+        },
+      };
+    });
+
+    const apolloClient = new ApolloClient({
+      link: authLink.concat(httpLink),
+      cache: new InMemoryCache(),
+    });
+
+    return apolloClient;
+  }, [tokenRef]);
+
+  return <ApolloProvider client={Client} {...props} />;
+};
+
+export default ApolloWrapper;

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
+
 import {Dimensions} from 'react-native';
 import {Provider} from 'react-redux';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
@@ -6,49 +7,49 @@ import {PersistGate} from 'redux-persist/integration/react';
 import {waitUntilSagasFinishLoading} from 'src/redux/saga';
 import {persistor, store} from '../redux/store';
 import {NavigatorWrapper} from 'src/navigator/NavigatorWrapper';
+import ApolloWrapper from '../apollo/ApolloWrapper';
 interface Props {
   appStartedMillis: number;
 }
 
-export class App extends React.Component<Props> {
-  reactLoadTime: number = Date.now();
+export const App = (props: Props) => {
+  const [reactLoadTime] = useState(Date.now());
 
-  async componentDidMount(): Promise<void> {
-    // @todo Catch when app is launched using deep link
-  }
+  useEffect(() => {
+    // @note Component did mount
+    return () => {
+      // @note Component will unmount
+    };
+  });
 
-  componentWillUnmount(): void {
-    // @todo Prepare for the app to be closed
-  }
-
-  logAppLoadTime() {
-    const {appStartedMillis} = this.props;
+  const logAppLoadTime = () => {
+    const {appStartedMillis} = props;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const readLoadDuration = (this.reactLoadTime - appStartedMillis) / 1000;
+    const readLoadDuration = (reactLoadTime - appStartedMillis) / 1000;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const appLoadDuration = (Date.now() - appStartedMillis) / 1000;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const {width, height} = Dimensions.get('window');
     // @todo Track telemetry on app launch
-  }
+  };
 
-  async handleOpenUrl() {
+  const handleOpenUrl = async () => {
     await waitUntilSagasFinishLoading();
     // @todo Handle deep link opening
-  }
+  };
 
-  render() {
-    return (
-      <SafeAreaProvider>
-        <Provider store={store}>
-          <PersistGate persistor={persistor}>
+  return (
+    <SafeAreaProvider>
+      <Provider store={store}>
+        <PersistGate persistor={persistor}>
+          <ApolloWrapper>
             {/* @todo Add App Navigation Wrapper */}
             <NavigatorWrapper />
-          </PersistGate>
-        </Provider>
-      </SafeAreaProvider>
-    );
-  }
-}
+          </ApolloWrapper>
+        </PersistGate>
+      </Provider>
+    </SafeAreaProvider>
+  );
+};
 
 export default App;

--- a/src/auth/actions.ts
+++ b/src/auth/actions.ts
@@ -1,22 +1,19 @@
+import {Auth0AuthorizationResponse} from './types';
+
 export enum Actions {
-  FIREBASE_AUTHORIZED = 'FIREBASE/AUTHORIZED',
-  AUTH0_AUTHORIZED = 'AUTH0/AUTHORIZED',
+  SET_ACCESS_TOKEN = 'AUTH/SET_ACCESS_TOKEN',
 }
 
-export interface FirebaseAuthorizedAction {
-  type: Actions.FIREBASE_AUTHORIZED;
+export interface SetAccessToken {
+  type: Actions.SET_ACCESS_TOKEN;
+  authorizationToken: Auth0AuthorizationResponse;
 }
 
-export const firebaseAuthorized = (): FirebaseAuthorizedAction => ({
-  type: Actions.FIREBASE_AUTHORIZED,
+export const setAccessToken = (
+  authorizationToken: Auth0AuthorizationResponse,
+): SetAccessToken => ({
+  type: Actions.SET_ACCESS_TOKEN,
+  authorizationToken,
 });
 
-export interface Auth0AuthorizedAction {
-  type: Actions.AUTH0_AUTHORIZED;
-}
-
-export const Auth0Authorized = (): Auth0AuthorizedAction => ({
-  type: Actions.AUTH0_AUTHORIZED,
-});
-
-export type ActionTypes = FirebaseAuthorizedAction | Auth0AuthorizedAction;
+export type ActionTypes = SetAccessToken;

--- a/src/auth/reducer.ts
+++ b/src/auth/reducer.ts
@@ -5,15 +5,18 @@ import {
 } from 'src/redux/persist-helper';
 import {ActionTypes} from 'src/actions';
 import {Actions} from './actions';
+import {Auth0AuthorizationResponse} from './types';
 
 export interface State {
   auth0Authorized: boolean;
   firebaseAuthorized: boolean;
+  authorizationToken: Auth0AuthorizationResponse | null;
 }
 
 const initialState: State = {
   auth0Authorized: false,
   firebaseAuthorized: false,
+  authorizationToken: null,
 };
 
 export const reducer = (
@@ -22,22 +25,16 @@ export const reducer = (
 ): State => {
   switch (action.type) {
     case REHYDRATE: {
-      const rehydratePayload = getRehydratePayload(action, 'app');
+      const rehydratePayload = getRehydratePayload(action, 'auth');
       return {
         ...state,
         ...rehydratePayload,
       };
     }
-    case Actions.AUTH0_AUTHORIZED: {
+    case Actions.SET_ACCESS_TOKEN: {
       return {
         ...state,
-        auth0Authorized: true,
-      };
-    }
-    case Actions.FIREBASE_AUTHORIZED: {
-      return {
-        ...state,
-        firebaseAuthorized: true,
+        authorizationToken: action.authorizationToken,
       };
     }
     default: {

--- a/src/auth/selectors.ts
+++ b/src/auth/selectors.ts
@@ -1,0 +1,6 @@
+import {RootState} from '../redux/reducers';
+import {Auth0AuthorizationResponse} from './types';
+
+export const authorizationTokenSelector = (
+  state: RootState,
+): Auth0AuthorizationResponse => state.auth.authorizationToken;

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -1,0 +1,7 @@
+export type Auth0AuthorizationResponse = {
+  accessToken: string;
+  expiresIn: number;
+  idToken: string;
+  scope: string;
+  tokenType: string;
+};

--- a/src/auth/useAuth.tsx
+++ b/src/auth/useAuth.tsx
@@ -1,6 +1,10 @@
+import {useDispatch} from 'react-redux';
+import {AUTH0_PASSWORDLESS_AUDIENCE} from '../config';
+import {setAccessToken} from './actions';
 import {auth0} from './init';
 
 export const useAuth0 = () => {
+  const dispatch = useDispatch();
   const start = async (phoneNumber: string) => {
     if (!phoneNumber) {
       return;
@@ -12,7 +16,16 @@ export const useAuth0 = () => {
     if (!phoneNumber) {
       return;
     }
-    return await auth0.auth.loginWithSMS({phoneNumber, code});
+    try {
+      const access = await auth0.auth.loginWithSMS({
+        phoneNumber,
+        code,
+        audience: AUTH0_PASSWORDLESS_AUDIENCE,
+      });
+      dispatch(setAccessToken(access));
+    } catch (error) {
+      console.error('Unable to get access token', error);
+    }
   };
 
   return {auth0, sendText: start, verifyText: finish};

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,8 +2,11 @@ import Constants from 'expo-constants';
 import {stringToBoolean} from './utils/parse';
 
 export const DEV_RESTORE_NAV_STATE_ON_RELOAD = stringToBoolean(
-  Constants.manifest.extra.DEV_RESTORE_NAV_STATE_ON_RELOAD || 'false',
+  Constants.manifest?.extra?.DEV_RESTORE_NAV_STATE_ON_RELOAD || 'false',
 );
 
-export const AUTH0_DOMAIN = Constants.manifest.extra.AUTH0_DOMAIN;
-export const AUTH0_CLIENT_ID = Constants.manifest.extra.AUTH0_CLIENT_ID;
+export const AUTH0_DOMAIN = Constants.manifest?.extra?.AUTH0_DOMAIN;
+export const AUTH0_PASSWORDLESS_AUDIENCE =
+  Constants.manifest?.extra?.AUTH0_PASSWORDLESS_AUDIENCE;
+export const AUTH0_CLIENT_ID = Constants.manifest?.extra?.AUTH0_CLIENT_ID;
+export const HASURA_URL = Constants.manifest?.extra?.HASURA_URL;

--- a/src/home/Home.tsx
+++ b/src/home/Home.tsx
@@ -20,12 +20,10 @@ const Home = () => {
   const submitPhoneNumber = () => {
     dispatch(setE146PhoneNumber(phoneNumber));
     sendText(phoneNumber);
-    console.log('Phone', phoneNumber);
   };
 
   const handleOTPCode = (code: string) => {
-    console.log('OTP', code);
-    verifyText(phoneNumber, code).then(console.log).catch(console.error);
+    verifyText(phoneNumber, code);
   };
 
   return (

--- a/src/navigator/Navigator.tsx
+++ b/src/navigator/Navigator.tsx
@@ -6,6 +6,10 @@ import Home from 'src/home/Home';
 import {AppLoading} from 'src/app/AppLoading';
 import {emptyHeader, noHeader} from './Headers';
 import {ExtractProps} from 'src/utils/typescript';
+import {useSelector} from 'react-redux';
+import {authorizationTokenSelector} from '../auth/selectors';
+import Transactions from '../transactions/Transactions';
+import {navigate} from './service';
 
 const Stack = createStackNavigator<StackParamList>();
 const RootStack = createStackNavigator<StackParamList>();
@@ -18,10 +22,21 @@ function MainStackScreen() {
   const [initialRouteName, setInitialRoute] =
     React.useState<InitialRouteName>(undefined);
 
+  const {accessToken} = useSelector(authorizationTokenSelector) || {};
+
   useEffect(() => {
-    const initialRoute = Screens.Home;
+    let initialRoute = Screens.Home;
+    if (accessToken) {
+      initialRoute = Screens.Transactions;
+    }
     setInitialRoute(initialRoute);
   }, []);
+
+  useEffect(() => {
+    if (accessToken) {
+      navigate(Screens.Transactions, {});
+    }
+  }, [accessToken]);
 
   if (!initialRouteName) {
     return <AppLoading />;
@@ -30,6 +45,7 @@ function MainStackScreen() {
   return (
     <Stack.Navigator initialRouteName={initialRouteName}>
       <Stack.Screen name={Screens.Home} component={Home} />
+      <Stack.Screen name={Screens.Transactions} component={Transactions} />
     </Stack.Navigator>
   );
 }

--- a/src/navigator/screens.ts
+++ b/src/navigator/screens.ts
@@ -3,4 +3,5 @@ export enum Screens {
   AppLoading = 'AppLoading',
   Home = 'Home',
   Settings = 'Settings',
+  Transactions = 'Transactions',
 }

--- a/src/navigator/service.ts
+++ b/src/navigator/service.ts
@@ -8,7 +8,8 @@ export const navigate = <RouteName extends keyof StackParamList>(
     ? [RouteName] | [RouteName, StackParamList[RouteName]]
     : [RouteName, StackParamList[RouteName]]
 ) => {
+  const [routeName, params] = args;
   if (navigationRef.isReady()) {
-    navigationRef.navigate(args);
+    navigationRef.navigate(routeName as never, params as never);
   }
 };

--- a/src/navigator/types.ts
+++ b/src/navigator/types.ts
@@ -5,4 +5,5 @@ export type StackParamList = {
   [Screens.Home]: undefined;
   [Screens.Settings]: undefined;
   [Screens.AppLoading]: undefined;
+  [Screens.Transactions]: undefined;
 };

--- a/src/redux/reducers.ts
+++ b/src/redux/reducers.ts
@@ -1,19 +1,30 @@
 import {Action, combineReducers} from 'redux';
 import {PersistState} from 'redux-persist';
 import {reducer as app, State as AppState} from 'src/app/reducers';
+import {reducer as auth, State as AuthState} from 'src/auth/reducer';
+import {
+  reducer as transactions,
+  State as TransactionState,
+} from 'src/transactions/reducer';
 
 export interface RootState {
   _persist: PersistState;
   app: AppState;
+  transactions: TransactionState;
+  auth: AuthState;
 }
 
 export interface PersistedRootState {
   _persist: PersistState;
   app: AppState;
+  transactions: TransactionState;
+  auth: AuthState;
 }
 
 const appReducer = combineReducers({
   app: app,
+  auth: auth,
+  transactions: transactions,
 }) as (state: RootState | undefined, action: Action) => RootState;
 
 const rootReducer = (

--- a/src/redux/saga.ts
+++ b/src/redux/saga.ts
@@ -1,7 +1,9 @@
 import {AnyAction} from 'redux';
 import {spawn, takeEvery} from 'redux-saga/effects';
 import {sleep} from 'src/utils/time';
+import {Actions as AuthActions} from '../auth/actions';
 import {authSaga} from '../auth/saga';
+import {REHYDRATE} from './persist-helper';
 
 let sagasFinishedLoading = false;
 
@@ -11,10 +13,19 @@ export const waitUntilSagasFinishLoading = async () => {
   }
 };
 
+const LoggerBlocklist = [REHYDRATE];
+
 function* loggerSaga() {
   yield takeEvery('*', (action: AnyAction) => {
     try {
-      console.debug('redux/saga@logger', JSON.stringify(action));
+      if (action?.type && LoggerBlocklist.includes(action.type)) {
+        console.debug(
+          'redux/saga@logger',
+          `${action.type} (payload not logged)`,
+        );
+      } else {
+        console.debug('redux/saga@logger', JSON.stringify(action));
+      }
     } catch (err) {
       console.warn(
         'redux/saga@logger',

--- a/src/transactions/Transactions.tsx
+++ b/src/transactions/Transactions.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import {View, Text} from 'react-native';
+import {SafeAreaView} from 'react-native-safe-area-context';
+import {useAllTransactions, useAllUsers} from './queries';
+
+const Transactions = () => {
+  const transactions = useAllTransactions();
+  const users = useAllUsers();
+
+  return (
+    <SafeAreaView>
+      <View>
+        <Text>All Transactions</Text>
+        <Text>{JSON.stringify(transactions?.error)}</Text>
+        <Text>{JSON.stringify(transactions?.data)}</Text>
+        <Text>{JSON.stringify(users?.error)}</Text>
+        <Text>{JSON.stringify(users?.data)}</Text>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+export default Transactions;

--- a/src/transactions/actions.ts
+++ b/src/transactions/actions.ts
@@ -1,0 +1,26 @@
+import {Transaction} from './types';
+
+export enum Actions {
+  ADD_TRANSACTION = 'TRX/ADD_TRANSACTION',
+  FETCH_TRANSACTIONS = 'TRX/FETCH_TRANSACTIONS',
+}
+
+export interface AddTransaction {
+  type: Actions.ADD_TRANSACTION;
+  transaction: Transaction;
+}
+
+export interface FetchTransactions {
+  type: Actions.FETCH_TRANSACTIONS;
+}
+
+export const addTransaction = (transaction: Transaction) => ({
+  type: Actions.ADD_TRANSACTION,
+  transaction,
+});
+
+export const FetchTransactions = () => ({
+  type: Actions.FETCH_TRANSACTIONS,
+});
+
+export type ActionTypes = AddTransaction | FetchTransactions;

--- a/src/transactions/queries.ts
+++ b/src/transactions/queries.ts
@@ -1,0 +1,30 @@
+import React from 'react';
+import {gql, useQuery} from '@apollo/client';
+
+export const ALL_TRANSACTIONS_QUERY = gql`
+  query GetAllTransactions {
+    transactions {
+      amount
+      currency
+      id
+    }
+  }
+`;
+
+export const ALL_USERS_QUERY = gql`
+  query GetAllUsers {
+    users {
+      id
+    }
+  }
+`;
+
+export const useAllTransactions = () => {
+  const {loading, error, data} = useQuery(ALL_TRANSACTIONS_QUERY, {});
+  return {loading, error, data};
+};
+
+export const useAllUsers = () => {
+  const {loading, error, data} = useQuery(ALL_USERS_QUERY, {});
+  return {loading, error, data};
+};

--- a/src/transactions/reducer.ts
+++ b/src/transactions/reducer.ts
@@ -1,0 +1,41 @@
+import {
+  getRehydratePayload,
+  REHYDRATE,
+  RehydrateAction,
+} from '../redux/persist-helper';
+import {Actions, ActionTypes} from './actions';
+import {Transaction} from './types';
+
+export interface State {
+  transactions: Transaction[];
+}
+
+const initialState: State = {
+  transactions: [],
+};
+
+export const reducer = (
+  state: State | undefined = initialState,
+  action: ActionTypes | RehydrateAction,
+): State => {
+  switch (action.type) {
+    case REHYDRATE: {
+      const rehydratePayload = getRehydratePayload(action, 'app');
+      return {
+        ...state,
+        ...rehydratePayload,
+      };
+    }
+    case Actions.ADD_TRANSACTION: {
+      return {
+        ...state,
+        transactions: [action.transaction, ...state.transactions],
+      };
+    }
+    default: {
+      return {
+        ...state,
+      };
+    }
+  }
+};

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -1,0 +1,6 @@
+export type Transaction = {
+  sender: string;
+  recipient: string;
+  amount: number;
+  currency: string;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,24 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@apollo/client@^3.6.9":
+  version "3.6.9"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.6.9.tgz#ad0ee2e3a3c92dbed4acd6917b6158a492739d94"
+  integrity sha512-Y1yu8qa2YeaCUBVuw08x8NHenFi0sw2I3KCu7Kw9mDSu86HmmtHJkCAifKVrN2iPgDTW/BbP3EpSV8/EQCcxZA==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.1.1"
+    "@wry/context" "^0.6.0"
+    "@wry/equality" "^0.5.0"
+    "@wry/trie" "^0.3.0"
+    graphql-tag "^2.12.6"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.16.1"
+    prop-types "^15.7.2"
+    symbol-observable "^4.0.0"
+    ts-invariant "^0.10.3"
+    tslib "^2.3.0"
+    zen-observable-ts "^1.2.5"
+
 "@babel/code-frame@7.10.4", "@babel/code-frame@~7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
@@ -2912,6 +2930,27 @@
     "@urql/core" ">=2.3.1"
     wonka "^4.0.14"
 
+"@wry/context@^0.6.0":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.6.1.tgz#c3c29c0ad622adb00f6a53303c4f965ee06ebeb2"
+  integrity sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/equality@^0.5.0":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.5.3.tgz#fafebc69561aa2d40340da89fa7dc4b1f6fb7831"
+  integrity sha512-avR+UXdSrsF2v8vIqIgmeTY0UR91UT+IyablCyKe/uk22uOJ8fusKZnH9JH9e1/EtLeNJBtagNmL3eJdnOV53g==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/trie@^0.3.0":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.3.2.tgz#a06f235dc184bd26396ba456711f69f8c35097e6"
+  integrity sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==
+  dependencies:
+    tslib "^2.3.0"
+
 "@xmldom/xmldom@~0.7.0":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.5.tgz#09fa51e356d07d0be200642b0e4f91d8e6dd408d"
@@ -5380,7 +5419,7 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6,
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-graphql-tag@^2.10.1:
+graphql-tag@^2.10.1, graphql-tag@^2.12.6:
   version "2.12.6"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
   integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
@@ -5391,6 +5430,11 @@ graphql@15.8.0:
   version "15.8.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.8.0.tgz#33410e96b012fa3bdb1091cc99a94769db212b38"
   integrity sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==
+
+graphql@^16.6.0:
+  version "16.6.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
+  integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
 
 growly@^1.3.0:
   version "1.3.0"
@@ -7957,6 +8001,14 @@ open@^8.0.4, open@^8.3.0:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
+optimism@^0.16.1:
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.16.1.tgz#7c8efc1f3179f18307b887e18c15c5b7133f6e7d"
+  integrity sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==
+  dependencies:
+    "@wry/context" "^0.6.0"
+    "@wry/trie" "^0.3.0"
+
 optionator@^0.8.1:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
@@ -9657,6 +9709,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+symbol-observable@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
+  integrity sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -9882,12 +9939,19 @@ ts-interface-checker@^0.1.9:
   resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
+ts-invariant@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.10.3.tgz#3e048ff96e91459ffca01304dbc7f61c1f642f6c"
+  integrity sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==
+  dependencies:
+    tslib "^2.1.0"
+
 tslib@^1.10.0, tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.1, tslib@^2.1.0:
+tslib@^2.0.1, tslib@^2.1.0, tslib@^2.3.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
@@ -10559,3 +10623,15 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zen-observable-ts@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz#6c6d9ea3d3a842812c6e9519209365a122ba8b58"
+  integrity sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==
+  dependencies:
+    zen-observable "0.8.15"
+
+zen-observable@0.8.15:
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
+  integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==


### PR DESCRIPTION
## Description

This PR hooks up the Apollo Client to the Hasura GraphQL service.

- [x] Store Auth0 authorization token on local storage
- [x] Use authorization token when configuring `@apollo/client` instance
- [x] When authenticated, the Transactions screen shows Transactions and Users that are pulled from the database with restricted access based on the user's privilege.

Apollo Client is configured with:
- [x] Points to Hasura endpoint
- [x] Headers include Auth0 access token

## User Privilege

The `user` role is default for all users, this role can access the following:

User Table
- ID

Transaction Table
- ID
- Amount
- Currency